### PR TITLE
Add permissions checks to ajax endpoint

### DIFF
--- a/InstanceTable.php
+++ b/InstanceTable.php
@@ -395,15 +395,20 @@ class InstanceTable extends AbstractExternalModule
                 // find any descriptive text fields tagged with @FORMINSTANCETABLE=form_name
                 $this->setTaggedFields();
                 $this->checkUserPermissions();
-        
+                
                 $hasPermissions = false;
                 foreach($this->taggedFields as $fieldDetails) {
                     if($fieldDetails["form_name"] == $form && $fieldDetails["permission_level"] > 0) {
                         $hasPermissions = true;
                     }
                 }
-        
-                if(!$hasPermissions) {
+	
+                $recordDag = $this->getDAG($record);
+                if(!empty($this->user_rights["group_id"]) && $this->user_rights["group_id"] != $recordDag) {
+                    $hasPermissions = false;
+                }
+
+				if(!$hasPermissions) {
                     return false;
                 }
                 

--- a/InstanceTable.php
+++ b/InstanceTable.php
@@ -389,7 +389,24 @@ class InstanceTable extends AbstractExternalModule
         public function getInstanceData($record, $event, $form, $fields, $filter, $includeFormStatus=true) {
                 $instanceData = array();
                 $filter = str_replace(self::REPLQUOTE_SINGLE,"'",str_replace(self::REPLQUOTE_DOUBLE,'"',$filter));
-
+	
+                ## Check user permissions for access to form with instance table or form with data
+        
+                // find any descriptive text fields tagged with @FORMINSTANCETABLE=form_name
+                $this->setTaggedFields();
+                $this->checkUserPermissions();
+        
+                $hasPermissions = false;
+                foreach($this->taggedFields as $fieldDetails) {
+                    if($fieldDetails["form_name"] == $form && $fieldDetails["permission_level"] > 0) {
+                        $hasPermissions = true;
+                    }
+                }
+        
+                if(!$hasPermissions) {
+                    return false;
+                }
+                
                 $repeatingFormFields = REDCap::getDataDictionary('array', false, null, $form);
 
                 // ignore any supplied fields not on the repeating form 


### PR DESCRIPTION
Add permissions check on getInstanceData to prevent direct access of ajax endpoint from going around permissions checks.

Currently, anyone with access to the project could hit the ajax endpoint directly and see a JSON version of all the form data. This pull request adds the checkUserPermissions check directly to the getInstanceData function so there's no way to avoid checking form level permissions.