### PR TITLE
fix array error.

### DIFF
--- a/InstanceTable.php
+++ b/InstanceTable.php
@@ -864,7 +864,7 @@ var <?php echo self::MODULE_VARNAME;?> = (function(window, document, $, app_path
                         $lastActionTagDesc = end(Form::getActionTags());
 
                         // which $lang element is this?
-                        $langElement = array_search($lastActionTagDesc, $this->lang);
+                        $langElement = array_search($lastActionTagDesc, is_array($this->lang)? $this->lang: []);
                         
                         $lastActionTagDesc .= "</td></tr>";
                         $lastActionTagDesc .= $this->makeTagTR(static::ACTION_TAG, static::ACTION_TAG_DESC);


### PR DESCRIPTION
This pull request is to solve below PHP 8.2 error. 

```
The 'instance_table' module threw the following exception when calling the hook method 'redcap_every_page_before_render':

TypeError: array_search(): Argument #2 ($haystack) must be of type array, null given in /var/www/html/modules/instance_table_v1.5.14/InstanceTable.php:867
```
